### PR TITLE
Check for redundant encryption configuration

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Infrastructure\DefaultServer.cs" />
     <Compile Include="Infrastructure\EndpointCustomizationConfigurationExtensions.cs" />
     <Compile Include="Infrastructure\NServiceBusAcceptanceTest.cs" />
+    <Compile Include="When_enabling_core_encryption_feature.cs" />
     <Compile Include="When_using_encryption_with_custom_service.cs" />
     <Compile Include="When_using_Rijndael_without_incoming_key_identifier.cs" />
     <Compile Include="When_using_Rijndael_with_custom.cs" />

--- a/src/AcceptanceTests/When_enabling_core_encryption_feature.cs
+++ b/src/AcceptanceTests/When_enabling_core_encryption_feature.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class When_enabling_core_encryption_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_at_startup()
+        {
+            var exception = Assert.ThrowsAsync<Exception>(() =>
+                Scenario.Define<ScenarioContext>()
+                    .WithEndpoint<EncryptionEndpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run());
+
+            StringAssert.Contains("The message property encryption extension as well as NServiceBus.Core's encryption feature are enabled. Disable one of the encryption features to avoid message payload corruption.", exception.Message);
+        }
+
+        class EncryptionEndpoint : EndpointConfigurationBuilder
+        {
+            public EncryptionEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    // ReSharper disable once InvokeAsExtensionMethod
+                    ConfigureRijndaelEncryptionService.RijndaelEncryptionService(c, "keyIdentifier1", new Dictionary<string, byte[]>()
+                    {
+                        {"keyIdentifier1", Encoding.ASCII.GetBytes("aaaaaaaaaabbbbbbbbbbcccc")}
+                    });
+                    NServiceBus.ConfigureRijndaelEncryptionService.RijndaelEncryptionService(c, "keyIdentifier2", new Dictionary<string, byte[]>
+                    {
+                        {"keyIdentifier2", Encoding.ASCII.GetBytes("ddddddddddeeeeeeeeeeffff")}
+                    });
+                });
+            }
+        }
+    }
+}

--- a/src/MessageProperty/ConfigureRijndaelEncryptionService.cs
+++ b/src/MessageProperty/ConfigureRijndaelEncryptionService.cs
@@ -100,6 +100,6 @@ namespace NServiceBus.Encryption.MessageProperty
             return settings.Get<Func<IEncryptionService>>(EncryptedServiceConstructorKey);
         }
 
-        internal const string EncryptedServiceConstructorKey = "Encryption.MessageProperty.EncryptionServiceConstructor";
+        internal const string EncryptedServiceConstructorKey = "MessagePropertyEncryptionServiceConstructor";
     }
 }

--- a/src/MessageProperty/ConfigureRijndaelEncryptionService.cs
+++ b/src/MessageProperty/ConfigureRijndaelEncryptionService.cs
@@ -100,6 +100,6 @@ namespace NServiceBus.Encryption.MessageProperty
             return settings.Get<Func<IEncryptionService>>(EncryptedServiceConstructorKey);
         }
 
-        internal const string EncryptedServiceConstructorKey = "MessagePropertyEncryptionServiceConstructor";
+        internal const string EncryptedServiceConstructorKey = "Encryption.MessageProperty.EncryptionServiceConstructor";
     }
 }

--- a/src/MessageProperty/DecryptBehavior.cs
+++ b/src/MessageProperty/DecryptBehavior.cs
@@ -52,7 +52,7 @@ namespace NServiceBus.Encryption.MessageProperty
         public class DecryptRegistration : RegisterStep
         {
             public DecryptRegistration(EncryptionInspector inspector, IEncryptionService encryptionService)
-                : base("InvokeDecryption", typeof(DecryptBehavior), "Invokes the decryption logic", b => new DecryptBehavior(inspector, encryptionService))
+                : base("MessagePropertyDecryption", typeof(DecryptBehavior), "Invokes the decryption logic", b => new DecryptBehavior(inspector, encryptionService))
             {
                 InsertBefore("MutateIncomingMessages");
             }

--- a/src/MessageProperty/EncryptBehavior.cs
+++ b/src/MessageProperty/EncryptBehavior.cs
@@ -56,7 +56,7 @@
         public class EncryptRegistration : RegisterStep
         {
             public EncryptRegistration(EncryptionInspector inspector, IEncryptionService encryptionService)
-                : base("InvokeEncryption", typeof(EncryptBehavior), "Invokes the encryption logic", b => new EncryptBehavior(inspector, encryptionService))
+                : base("MessagePropertyEncryption", typeof(EncryptBehavior), "Invokes the encryption logic", b => new EncryptBehavior(inspector, encryptionService))
             {
                 InsertAfter("MutateOutgoingMessages");
             }

--- a/src/MessageProperty/Encryption.cs
+++ b/src/MessageProperty/Encryption.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Encryption.MessageProperty
 {
+    using System;
     using Features;
 
     class Encryption : Feature
@@ -13,6 +14,13 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
+            // check if the encryption service in the core has been enabled.
+            // this check can be removed when encryption has been fully obsoleted in the core.
+            if (context.Settings.HasSetting("EncryptionServiceConstructor"))
+            {
+                throw new Exception("The message property encryption extension as well as NServiceBus.Core's encryption feature are enabled. Disable one of the encryption features to avoid message payload corruption.");
+            }
+
             var serviceConstructor = context.Settings.GetEncryptionServiceConstructor();
             var service = serviceConstructor();
             var inspector = new EncryptionInspector(context.Settings.Get<Conventions>());


### PR DESCRIPTION
* Check if the core configured the RijndaelEncryptionService and stop the endpoint from starting to avoid potential issues with message mutators.
* Adds an acceptance test to verify the described behavior
* Change configuration and behavior ids to be different from the core to avoid duplicate key issues

please review @kbaley @SimonCropp 