### PR TITLE
Rename WireEncryptedString to EncryptedString

### DIFF
--- a/src/AcceptanceTests/When_receiving_legacy_type.cs
+++ b/src/AcceptanceTests/When_receiving_legacy_type.cs
@@ -73,7 +73,7 @@
 
         class MessageWithLegacyEncryptedPropertyType : ICommand
         {
-            public NServiceBus.WireEncryptedString Value { get; set; }
+            public WireEncryptedString Value { get; set; }
         }
     }
 }

--- a/src/AcceptanceTests/When_sending_legacy_type.cs
+++ b/src/AcceptanceTests/When_sending_legacy_type.cs
@@ -73,7 +73,7 @@
 
         class MessageWithLegacyEncryptedPropertyType : ICommand
         {
-            public NServiceBus.WireEncryptedString Value { get; set; }
+            public WireEncryptedString Value { get; set; }
         }
     }
 }

--- a/src/AcceptanceTests/When_using_Rijndael_with_custom.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_with_custom.cs
@@ -94,7 +94,7 @@
 
         public class MessageWithSecretData : IMessage
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
             public MySecretSubProperty SubProperty { get; set; }
             public List<CreditCardDetails> CreditCards { get; set; }
         }
@@ -102,12 +102,12 @@
         public class CreditCardDetails
         {
             public DateTime ValidTo { get; set; }
-            public WireEncryptedString Number { get; set; }
+            public EncryptedString Number { get; set; }
         }
 
         public class MySecretSubProperty
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
         }
     }
 }

--- a/src/AcceptanceTests/When_using_Rijndael_with_multikey.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_with_multikey.cs
@@ -72,7 +72,7 @@
 
         public class MessageWithSecretData : IMessage
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
         }
     }
 }

--- a/src/AcceptanceTests/When_using_Rijndael_without_incoming_key_identifier.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_without_incoming_key_identifier.cs
@@ -73,7 +73,7 @@
 
         public class MessageWithSecretData : IMessage
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
         }
 
         class RemoveKeyIdentifierHeaderMutator : IMutateIncomingTransportMessages, INeedInitialization

--- a/src/AcceptanceTests/When_using_encryption_with_custom_service.cs
+++ b/src/AcceptanceTests/When_using_encryption_with_custom_service.cs
@@ -90,7 +90,7 @@
 
         public class MessageWithSecretData : IMessage
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
             public MySecretSubProperty SubProperty { get; set; }
             public List<CreditCardDetails> CreditCards { get; set; }
         }
@@ -98,12 +98,12 @@
         public class CreditCardDetails
         {
             public DateTime ValidTo { get; set; }
-            public WireEncryptedString Number { get; set; }
+            public EncryptedString Number { get; set; }
         }
 
         public class MySecretSubProperty
         {
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
         }
 
         public class MyEncryptionService : IEncryptionService

--- a/src/MessageProperty/DecryptBehavior.cs
+++ b/src/MessageProperty/DecryptBehavior.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Encryption.MessageProperty
         {
             var encryptedValue = property.GetValue(target);
 
-            var wireEncryptedString = encryptedValue as WireEncryptedString;
+            var wireEncryptedString = encryptedValue as EncryptedString;
             if (wireEncryptedString != null)
             {
                 encryptionService.DecryptValue(wireEncryptedString, context);
@@ -45,7 +45,7 @@ namespace NServiceBus.Encryption.MessageProperty
                 property.SetValue(target, stringToDecrypt);
             }
 
-            var legacyWireEncryptedString = encryptedValue as NServiceBus.WireEncryptedString;
+            var legacyWireEncryptedString = encryptedValue as WireEncryptedString;
             if (legacyWireEncryptedString != null)
             {
                 encryptionService.DecryptValue(legacyWireEncryptedString, context);

--- a/src/MessageProperty/EncryptBehavior.cs
+++ b/src/MessageProperty/EncryptBehavior.cs
@@ -31,7 +31,7 @@
         {
             var valueToEncrypt = member.GetValue(message);
 
-            var wireEncryptedString = valueToEncrypt as WireEncryptedString;
+            var wireEncryptedString = valueToEncrypt as EncryptedString;
             if (wireEncryptedString != null)
             {
                 encryptionService.EncryptValue(wireEncryptedString, context);
@@ -47,7 +47,7 @@
                 return;
             }
 
-            var legacyWireEncryptedString = valueToEncrypt as NServiceBus.WireEncryptedString;
+            var legacyWireEncryptedString = valueToEncrypt as WireEncryptedString;
             if (legacyWireEncryptedString != null)
             {
                 encryptionService.EncryptValue(legacyWireEncryptedString, context);

--- a/src/MessageProperty/EncryptedString.cs
+++ b/src/MessageProperty/EncryptedString.cs
@@ -7,19 +7,19 @@
     /// A string whose value will be encrypted when sent over the wire.
     /// </summary>
     [Serializable]
-    public class WireEncryptedString : ISerializable
+    public class EncryptedString : ISerializable
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="WireEncryptedString" />.
+        /// Initializes a new instance of <see cref="EncryptedString" />.
         /// </summary>
-        public WireEncryptedString()
+        public EncryptedString()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="WireEncryptedString" />.
+        /// Initializes a new instance of <see cref="EncryptedString" />.
         /// </summary>
-        public WireEncryptedString(SerializationInfo info, StreamingContext context)
+        public EncryptedString(SerializationInfo info, StreamingContext context)
         {
             Guard.AgainstNull(nameof(info), info);
             EncryptedValue = info.GetValue("EncryptedValue", typeof(EncryptedValue)) as EncryptedValue;
@@ -53,7 +53,7 @@
         /// <summary>
         /// Gets the string value from the WireEncryptedString.
         /// </summary>
-        public static implicit operator string(WireEncryptedString s)
+        public static implicit operator string(EncryptedString s)
         {
             return s?.Value;
         }
@@ -61,9 +61,9 @@
         /// <summary>
         /// Creates a new WireEncryptedString from the given string.
         /// </summary>
-        public static implicit operator WireEncryptedString(string s)
+        public static implicit operator EncryptedString(string s)
         {
-            return new WireEncryptedString
+            return new EncryptedString
             {
                 Value = s
             };

--- a/src/MessageProperty/EncryptedStringConversions.cs
+++ b/src/MessageProperty/EncryptedStringConversions.cs
@@ -3,15 +3,15 @@ namespace NServiceBus.Encryption.MessageProperty
     using System;
     using Pipeline;
 
-    static class WireEncryptedStringConversions
+    static class EncryptedStringConversions
     {
-        public static void EncryptValue(this IEncryptionService encryptionService, WireEncryptedString wireEncryptedString, IOutgoingLogicalMessageContext context)
+        public static void EncryptValue(this IEncryptionService encryptionService, EncryptedString encryptedString, IOutgoingLogicalMessageContext context)
         {
-            wireEncryptedString.EncryptedValue = encryptionService.Encrypt(wireEncryptedString.Value, context);
-            wireEncryptedString.Value = null;
+            encryptedString.EncryptedValue = encryptionService.Encrypt(encryptedString.Value, context);
+            encryptedString.Value = null;
         }
 
-        public static void EncryptValue(this IEncryptionService encryptionService, NServiceBus.WireEncryptedString wireEncryptedString, IOutgoingLogicalMessageContext context)
+        public static void EncryptValue(this IEncryptionService encryptionService, WireEncryptedString wireEncryptedString, IOutgoingLogicalMessageContext context)
         {
             var ev = encryptionService.Encrypt(wireEncryptedString.Value, context);
             wireEncryptedString.EncryptedValue = new NServiceBus.EncryptedValue
@@ -22,17 +22,17 @@ namespace NServiceBus.Encryption.MessageProperty
             wireEncryptedString.Value = null;
         }
 
-        public static void DecryptValue(this IEncryptionService encryptionService, WireEncryptedString wireEncryptedString, IIncomingLogicalMessageContext context)
+        public static void DecryptValue(this IEncryptionService encryptionService, EncryptedString encryptedString, IIncomingLogicalMessageContext context)
         {
-            if (wireEncryptedString.EncryptedValue == null)
+            if (encryptedString.EncryptedValue == null)
             {
                 throw new Exception("Encrypted property is missing encryption data");
             }
 
-            wireEncryptedString.Value = encryptionService.Decrypt(wireEncryptedString.EncryptedValue, context);
+            encryptedString.Value = encryptionService.Decrypt(encryptedString.EncryptedValue, context);
         }
 
-        public static void DecryptValue(this IEncryptionService encryptionService, NServiceBus.WireEncryptedString wireEncryptedString, IIncomingLogicalMessageContext context)
+        public static void DecryptValue(this IEncryptionService encryptionService, WireEncryptedString wireEncryptedString, IIncomingLogicalMessageContext context)
         {
             if (wireEncryptedString.EncryptedValue == null)
             {

--- a/src/MessageProperty/EncryptionConfigurationExtensions.cs
+++ b/src/MessageProperty/EncryptionConfigurationExtensions.cs
@@ -29,7 +29,7 @@
         /// </summary>
         /// <param name="configuration">The endpoint configurartion to extend.</param>
         /// <param name="encryptionService">The encryption service used to encrypt and decrypt message properties.</param>
-        /// <param name="encryptedPropertyConvention">The convention which defines which properties should be encrypted. By default, all properties of type <see cref="NServiceBus.WireEncryptedString"/> will be encrypted.</param>
+        /// <param name="encryptedPropertyConvention">The convention which defines which properties should be encrypted. By default, all properties of type <see cref="EncryptedString"/> and <see cref="WireEncryptedString"/> will be encrypted.</param>
         public static void EnableMessagePropertyEncryption(this EndpointConfiguration configuration, IEncryptionService encryptionService, Func<PropertyInfo, bool> encryptedPropertyConvention)
         {
             Guard.AgainstNull(nameof(encryptedPropertyConvention), encryptedPropertyConvention);

--- a/src/MessageProperty/EncryptionInspector.cs
+++ b/src/MessageProperty/EncryptionInspector.cs
@@ -42,7 +42,7 @@ namespace NServiceBus.Encryption.MessageProperty
             var fieldInfo = arg as FieldInfo;
             if (fieldInfo != null)
             {
-                return fieldInfo.FieldType == typeof(WireEncryptedString) || fieldInfo.FieldType == typeof(NServiceBus.WireEncryptedString);
+                return fieldInfo.FieldType == typeof(EncryptedString) || fieldInfo.FieldType == typeof(WireEncryptedString);
             }
 
             return false;
@@ -72,7 +72,7 @@ namespace NServiceBus.Encryption.MessageProperty
                 if (IsEncryptedMember(member) && member.GetValue(root) != null)
                 {
                     var value = member.GetValue(root);
-                    if (value is string || value is WireEncryptedString || value is NServiceBus.WireEncryptedString)
+                    if (value is string || value is EncryptedString || value is WireEncryptedString)
                     {
                         properties.Add(Tuple.Create(root, member));
                         continue;
@@ -87,7 +87,7 @@ namespace NServiceBus.Encryption.MessageProperty
                 }
 
                 // don't try to recurse over members of WireEncryptedString
-                if (member.DeclaringType == typeof(WireEncryptedString) || member.DeclaringType == typeof(NServiceBus.WireEncryptedString))
+                if (member.DeclaringType == typeof(EncryptedString) || member.DeclaringType == typeof(WireEncryptedString))
                 {
                     continue;
                 }

--- a/src/MessageProperty/MessagePropertyEncryption.cs
+++ b/src/MessageProperty/MessagePropertyEncryption.cs
@@ -9,8 +9,8 @@
         {
             Defaults(s => s.SetDefault<IsEncryptedPropertyConvention>(
                 new IsEncryptedPropertyConvention(p =>
-                typeof(WireEncryptedString).IsAssignableFrom(p.PropertyType)
-                || typeof(NServiceBus.WireEncryptedString).IsAssignableFrom(p.PropertyType))));
+                typeof(EncryptedString).IsAssignableFrom(p.PropertyType)
+                || typeof(WireEncryptedString).IsAssignableFrom(p.PropertyType))));
         }
 
         protected override void Setup(FeatureConfigurationContext context)

--- a/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
+++ b/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
@@ -70,8 +70,8 @@
     <Compile Include="Utils\Guard.cs" />
     <Compile Include="Utils\DelegateFactory.cs" />
     <Compile Include="Utils\ExtensionMethods.cs" />
-    <Compile Include="WireEncryptedString.cs" />
-    <Compile Include="WireEncryptedStringConversions.cs" />
+    <Compile Include="EncryptedString.cs" />
+    <Compile Include="EncryptedStringConversions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -4,6 +4,14 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
 namespace NServiceBus.Encryption.MessageProperty
 {
+    public class EncryptedString : System.Runtime.Serialization.ISerializable
+    {
+        public EncryptedString() { }
+        public EncryptedString(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public NServiceBus.Encryption.MessageProperty.EncryptedValue EncryptedValue { get; set; }
+        public string Value { get; set; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public class EncryptedValue
     {
         public EncryptedValue() { }
@@ -30,13 +38,5 @@ namespace NServiceBus.Encryption.MessageProperty
         public string Decrypt(NServiceBus.Encryption.MessageProperty.EncryptedValue encryptedValue, NServiceBus.Pipeline.IIncomingLogicalMessageContext context) { }
         public NServiceBus.Encryption.MessageProperty.EncryptedValue Encrypt(string value, NServiceBus.Pipeline.IOutgoingLogicalMessageContext context) { }
         protected virtual bool TryGetKeyIdentifierHeader(out string keyIdentifier, NServiceBus.Pipeline.IIncomingLogicalMessageContext context) { }
-    }
-    public class WireEncryptedString : System.Runtime.Serialization.ISerializable
-    {
-        public WireEncryptedString() { }
-        public WireEncryptedString(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public NServiceBus.Encryption.MessageProperty.EncryptedValue EncryptedValue { get; set; }
-        public string Value { get; set; }
-        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }

--- a/src/Tests/When_decrypting_a_member_that_is_missing_encryption_data.cs
+++ b/src/Tests/When_decrypting_a_member_that_is_missing_encryption_data.cs
@@ -15,13 +15,13 @@
                 Base64Iv = "Base64Iv"
             });
 
-            var value = new WireEncryptedString
+            var value = new EncryptedString
             {
                 Value = "The real value"
             };
 
             // ReSharper disable once InvokeAsExtensionMethod
-            var exception = Assert.Throws<Exception>(() => WireEncryptedStringConversions.DecryptValue(service, value, null));
+            var exception = Assert.Throws<Exception>(() => EncryptedStringConversions.DecryptValue(service, value, null));
             Assert.AreEqual("Encrypted property is missing encryption data", exception.Message);
         }
     }

--- a/src/Tests/When_sending_a_message_with_2x_compatibility_disabled.cs
+++ b/src/Tests/When_sending_a_message_with_2x_compatibility_disabled.cs
@@ -14,7 +14,7 @@
                 Base64Iv = "Base64Iv"
             });
 
-            var value = (WireEncryptedString) MySecretMessage;
+            var value = (EncryptedString) MySecretMessage;
 
             service.EncryptValue(value, null);
             Assert.AreEqual(value.EncryptedValue.EncryptedBase64Value, EncryptedBase64Value);

--- a/src/Tests/WireEncryptedStringSpecs.cs
+++ b/src/Tests/WireEncryptedStringSpecs.cs
@@ -74,7 +74,7 @@
                 set { indexedList[index] = value; }
             }
 
-            public WireEncryptedString Secret { get; set; }
+            public EncryptedString Secret { get; set; }
         }
     }
 
@@ -95,9 +95,9 @@
 
         public class MessageWithIndexedProperties : IMessage
         {
-            WireEncryptedString[] indexedList = new WireEncryptedString[2];
+            EncryptedString[] indexedList = new EncryptedString[2];
 
-            public WireEncryptedString this[int index]
+            public EncryptedString this[int index]
             {
                 get { return indexedList[index]; }
                 set { indexedList[index] = value; }
@@ -142,16 +142,16 @@
             inspector
                 .ScanObject(message)
                 .ToList()
-                .ForEach(x => x.Item2.SetValue(x.Item1, (WireEncryptedString)MySecretMessage));
+                .ForEach(x => x.Item2.SetValue(x.Item1, (EncryptedString)MySecretMessage));
 
             Assert.AreEqual(MySecretMessage, message.MySecret.Value);
         }
 
         public class MessageWithPropertyWithBackingPublicField : IMessage
         {
-            public WireEncryptedString mySuperSecret;
+            public EncryptedString mySuperSecret;
 
-            public WireEncryptedString MySecret
+            public EncryptedString MySecret
             {
                 get { return mySuperSecret; }
                 set { mySuperSecret = value; }
@@ -219,12 +219,12 @@
 
         protected virtual Func<PropertyInfo, bool> BuildConventions()
         {
-            return property => typeof(WireEncryptedString).IsAssignableFrom(property.PropertyType);
+            return property => typeof(EncryptedString).IsAssignableFrom(property.PropertyType);
         }
 
-        protected WireEncryptedString Create()
+        protected EncryptedString Create()
         {
-            return new WireEncryptedString
+            return new EncryptedString
             {
                 EncryptedValue = new EncryptedValue
                 {
@@ -243,10 +243,10 @@
 
     public class Customer : IMessage
     {
-        public WireEncryptedString Secret { get; set; }
-        public WireEncryptedString SecretField;
+        public EncryptedString Secret { get; set; }
+        public EncryptedString SecretField;
         public CreditCardDetails CreditCard { get; set; }
-        public WireEncryptedString SecretThatIsNull { get; set; }
+        public EncryptedString SecretThatIsNull { get; set; }
         public DateTime DateTime { get; set; }
         public List<CreditCardDetails> ListOfCreditCards { get; set; }
         public ArrayList ListOfSecrets { get; set; }
@@ -255,17 +255,17 @@
 
     public class CreditCardDetails
     {
-        public WireEncryptedString CreditCardNumber { get; set; }
+        public EncryptedString CreditCardNumber { get; set; }
     }
 
     public class SecureMessageWithProtectedSetter : IMessage
     {
-        public SecureMessageWithProtectedSetter(WireEncryptedString secret)
+        public SecureMessageWithProtectedSetter(EncryptedString secret)
         {
             Secret = secret;
         }
 
-        public WireEncryptedString Secret { get; protected set; }
+        public EncryptedString Secret { get; protected set; }
     }
 
     public class MessageWithCircularReferences : IMessage
@@ -276,13 +276,13 @@
 
     public class MessageWithMissingData : IMessage
     {
-        public WireEncryptedString Secret { get; set; }
+        public EncryptedString Secret { get; set; }
     }
 
     public class SubProperty
     {
         public MessageWithCircularReferences Parent { get; set; }
-        public WireEncryptedString Secret { get; set; }
+        public EncryptedString Secret { get; set; }
         public SubProperty Self { get; set; }
     }
 


### PR DESCRIPTION
to avoid confusion around name conflicts with `WireEncryptedString`

`WireEncryptedString` remains in the core and now shows a compiler warning about its obsoletion. In the next major it will even throw a compilation error and therefore users have to always specify the full NServiceBus.Encryption.MessageProperty.WireEncryptedString namespace for message contracts which becomes tedious. I think it's easier to rename the type in this package to EncryptedString to avoid this confusion and noise for users.

ping @SimonCropp @kbaley 