### PR TITLE
System.FormatException: Invalid format string in RijndaelEncryptionService when used with Microsoft.Extensions.Logging

### DIFF
--- a/src/MessageProperty/RijndaelEncryptionService.cs
+++ b/src/MessageProperty/RijndaelEncryptionService.cs
@@ -243,7 +243,7 @@ namespace NServiceBus.Encryption.MessageProperty
                 var maxValidKeyBitLength = rijndael.LegalKeySizes.Max(keyLength => keyLength.MaxSize);
                 if (bitLength < maxValidKeyBitLength)
                 {
-                    Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Consider using a {1}-bit encryption key to obtain the maximum cipher strength", bitLength, maxValidKeyBitLength);
+                    Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Consider using a {2}-bit encryption key to obtain the maximum cipher strength", bitLength, maxValidKeyBitLength, maxValidKeyBitLength);
                 }
 
                 return rijndael.ValidKeySize(bitLength);


### PR DESCRIPTION
Backport of #86 to `release-2.0`

No backport for `release-1.0` needed because `NServiceBus.Extensions.Logging` only support NServiceBus v7 and higher

## Who's affected

Customers using `RijndaelEncryptionService` using a key with bit length that is smaller than the maximum valid key bit length in combination with `Microsoft.Extensions.Logging`.

## Symptoms

The endpoint cannot be started and fails with

```
System.FormatException: Invalid format string. Expected 2 format parameters, but failed to lookup parameter index 1
 ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Microsoft.Extensions.Logging.LogValuesFormatter.GetValue(Object[] values, Int32 index)
   at Microsoft.Extensions.Logging.FormattedLogValues.get_Item(Int32 index)

```