### PR TITLE
MessagePropertyEncryption: Core alpha 910

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -71,11 +71,11 @@
     update_type: all
 
 - match:
-    dependency_name: Particular.Approvals
+    dependency_name: Particular.Analyzers
     update_type: all
 
 - match:
-    dependency_name: Particular.CodeRules
+    dependency_name: Particular.Approvals
     update_type: all
 
 - match:

--- a/src/AcceptanceTests/.editorconfig
+++ b/src/AcceptanceTests/.editorconfig
@@ -2,3 +2,6 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# may be enabled in future
+dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/AcceptanceTests/Infrastructure/DefaultServer.cs
+++ b/src/AcceptanceTests/Infrastructure/DefaultServer.cs
@@ -6,7 +6,6 @@
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
     using Configuration.AdvancedExtensibility;
-    using Features;
     using Microsoft.Extensions.DependencyInjection;
 
     public class DefaultServer : IEndpointSetupTemplate
@@ -21,9 +20,7 @@
             this.typesToInclude = typesToInclude;
         }
 
-#pragma warning disable 618
         public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
-#pragma warning restore 618
         {
             var types = endpointConfiguration.GetTypesScopedByTestClass();
 
@@ -34,13 +31,11 @@
             configuration.TypesToIncludeInScan(typesToInclude);
             configuration.EnableInstallers();
 
-            configuration.DisableFeature<TimeoutManager>();
-
             var recoverability = configuration.Recoverability();
             recoverability.Delayed(delayed => delayed.NumberOfRetries(0));
             recoverability.Immediate(immediate => immediate.NumberOfRetries(0));
 
-            configuration.UseTransport<LearningTransport>();
+            configuration.UseTransport(new LearningTransport());
 
             configuration.RegisterComponents(r =>
             {

--- a/src/AcceptanceTests/Infrastructure/EndpointConfigurationExtensions.cs
+++ b/src/AcceptanceTests/Infrastructure/EndpointConfigurationExtensions.cs
@@ -1,12 +1,14 @@
 ﻿namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests
 {
     using Configuration.AdvancedExtensibility;
+    using NServiceBus.Transport;
 
     public static class EndpointConfigurationExtensions
     {
-        public static TransportExtensions ConfigureTransport(this EndpointConfiguration endpointConfiguration)
-        {
-            return new TransportExtensions(endpointConfiguration.GetSettings());
-        }
+        public static TransportDefinition ConfigureTransport(this EndpointConfiguration endpointConfiguration) =>
+            endpointConfiguration.GetSettings().Get<TransportDefinition>();
+
+        public static RoutingSettings ConfigureRouting(this EndpointConfiguration configuration) =>
+            new RoutingSettings(configuration.GetSettings());
     }
 }

--- a/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.910" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.940" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.631" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.910" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/AcceptanceTests/When_using_Rijndael_with_multikey.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_with_multikey.cs
@@ -37,8 +37,7 @@
                 EndpointSetup<DefaultServer>(builder =>
                 {
                     builder.EnableMessagePropertyEncryption(new RijndaelEncryptionService("1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")));
-                    builder.ConfigureTransport()
-                        .Routing()
+                    builder.ConfigureRouting()
                         .RouteToEndpoint(typeof(MessageWithSecretData), Conventions.EndpointNamingConvention(typeof(Receiver)));
                 });
             }

--- a/src/AcceptanceTests/When_using_Rijndael_with_unobtrusive_mode.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_with_unobtrusive_mode.cs
@@ -75,8 +75,7 @@ namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests
 
                     c.EnableMessagePropertyEncryption(new RijndaelEncryptionService("1st", Keys), t => t.Name.StartsWith("Encrypted"));
 
-                    c.ConfigureTransport()
-                        .Routing()
+                    c.ConfigureRouting()
                         .RouteToEndpoint(typeof(MessageWithSecretData), Conventions.EndpointNamingConvention(typeof(Receiver)));
                 })
                 // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode

--- a/src/AcceptanceTests/When_using_Rijndael_without_incoming_key_identifier.cs
+++ b/src/AcceptanceTests/When_using_Rijndael_without_incoming_key_identifier.cs
@@ -38,8 +38,7 @@
                 EndpointSetup<DefaultServer>(builder =>
                 {
                     builder.EnableMessagePropertyEncryption(new RijndaelEncryptionService("will-be-removed-by-transport-mutator", Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
-                    builder.ConfigureTransport()
-                        .Routing()
+                    builder.ConfigureRouting()
                         .RouteToEndpoint(typeof(MessageWithSecretData), Conventions.EndpointNamingConvention(typeof(Receiver)));
                 });
             }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,8 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>5.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
+    <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">1.0.0</ParticularAnalyzersVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CI)' != '' Or '$(TEAMCITY_VERSION)' != ''">
@@ -14,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.CodeRules" Version="0.8.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
+++ b/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.631, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.910, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
+++ b/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.910, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.940, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Tests/NServiceBus.Encryption.MessageProperty.Tests.csproj
+++ b/src/Tests/NServiceBus.Encryption.MessageProperty.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.910" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.940" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />


### PR DESCRIPTION
There's really nothing task-returning in the library (due to encryption APIs not being async) except for the encrypt/decrypt behaviors which have the token on the context.