### PR TITLE
Revert spike #283 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v2.1.0
         with:
-          dotnet-version: |
-            7.0.x
-            6.0.x
-          include-prerelease: true
+          dotnet-version: 6.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Encryption.MessageProperty.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
+++ b/src/MessageProperty/NServiceBus.Encryption.MessageProperty.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>Selectively encrypt NServiceBus message properties</Description>

--- a/src/Tests/NServiceBus.Encryption.MessageProperty.Tests.csproj
+++ b/src/Tests/NServiceBus.Encryption.MessageProperty.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Optimize>false</Optimize>


### PR DESCRIPTION
It seems #283 was merged but I don't think that should have happened. It seems it was a spike.

but... now that RC is out we might want to start targeting NET7 on master branches so likely this does not really need to be reverted on master?

