### PR TITLE
Standardize encryption key headers

### DIFF
--- a/src/AcceptanceTests/When_using_Aes_without_incoming_key_identifier.cs
+++ b/src/AcceptanceTests/When_using_Aes_without_incoming_key_identifier.cs
@@ -91,7 +91,7 @@
         {
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
-                context.Headers.Remove(EncryptionHeaders.AesKeyIdentifier);
+                context.Headers.Remove(EncryptionHeaders.EncryptionKeyIdentifier);
                 return Task.FromResult(0);
             }
         }

--- a/src/MessageProperty/AesEncryptionService.cs
+++ b/src/MessageProperty/AesEncryptionService.cs
@@ -111,7 +111,7 @@ namespace NServiceBus.Encryption.MessageProperty
             {
                 return DecryptUsingKeyIdentifier(encryptedValue, keyIdentifier);
             }
-            Log.Warn($"Encrypted message has no '{EncryptionHeaders.AesKeyIdentifier}' header. Possibility of data corruption. Upgrade endpoints that send message with encrypted properties.");
+            Log.Warn($"Encrypted message has no '{EncryptionHeaders.EncryptionKeyIdentifier}' header. Possibility of data corruption. Upgrade endpoints that send message with encrypted properties.");
             return DecryptUsingAllKeys(encryptedValue);
         }
 
@@ -252,8 +252,7 @@ namespace NServiceBus.Encryption.MessageProperty
         /// </summary>
         protected internal virtual void AddKeyIdentifierHeader(IOutgoingLogicalMessageContext context)
         {
-            context.Headers[EncryptionHeaders.AesKeyIdentifier] = encryptionKeyIdentifier;
-            context.Headers[EncryptionHeaders.RijndaelKeyIdentifier] = encryptionKeyIdentifier;
+            context.Headers[EncryptionHeaders.EncryptionKeyIdentifier] = encryptionKeyIdentifier;
         }
 
         /// <summary>
@@ -261,7 +260,7 @@ namespace NServiceBus.Encryption.MessageProperty
         /// </summary>
         protected internal virtual bool TryGetKeyIdentifierHeader(out string keyIdentifier, IIncomingLogicalMessageContext context)
         {
-            return context.Headers.TryGetValue(EncryptionHeaders.AesKeyIdentifier, out keyIdentifier);
+            return context.Headers.TryGetValue(EncryptionHeaders.EncryptionKeyIdentifier, out keyIdentifier);
         }
 
         /// <summary>

--- a/src/MessageProperty/EncryptionHeaders.cs
+++ b/src/MessageProperty/EncryptionHeaders.cs
@@ -8,10 +8,6 @@
         /// <summary>
         /// The identifier to lookup the key to decrypt the encrypted data.
         /// </summary>
-        public const string RijndaelKeyIdentifier = "NServiceBus.RijndaelKeyIdentifier";
-        /// <summary>
-        /// The AES identifier to lookup the key to decrypt the encrypted data.
-        /// </summary>
-        public const string AesKeyIdentifier = "NServiceBus.AesKeyIdentifier";
+        public const string EncryptionKeyIdentifier = "NServiceBus.RijndaelKeyIdentifier";
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -39,8 +39,7 @@ namespace NServiceBus.Encryption.MessageProperty
     }
     public static class EncryptionHeaders
     {
-        public const string AesKeyIdentifier = "NServiceBus.AesKeyIdentifier";
-        public const string RijndaelKeyIdentifier = "NServiceBus.RijndaelKeyIdentifier";
+        public const string EncryptionKeyIdentifier = "NServiceBus.RijndaelKeyIdentifier";
     }
     public interface IEncryptionService
     {


### PR DESCRIPTION
This is to ensure backward compatibility between messages encrypted with Rijndael and ones encrypted with AES