### PR TITLE
Reuse of encrypted properties results in downstream data corruption

### DIFF
--- a/src/AcceptanceTests/When_sending_the_same_message_twice.cs
+++ b/src/AcceptanceTests/When_sending_the_same_message_twice.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using NUnit.Framework;
+
+public class When_sending_the_same_message_twice : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_not_corrupt_encrypted_properties()
+    {
+        var secret = "betcha can't guess my secret";
+        var messageToReuse = new MessageWithSecretData
+        {
+            Secret = secret,
+            EncryptedString = secret,
+            SubProperty = new MySecretSubProperty { Secret = secret }
+        };
+
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Endpoint>(b => b.When(async session =>
+            {
+                await session.SendLocal(messageToReuse);
+                await session.SendLocal(messageToReuse);
+            }))
+            .Run();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var message in context.MessagesReceived)
+            {
+                Assert.That(message.Secret.Value, Is.EqualTo(secret));
+                Assert.That(message.EncryptedString, Is.EqualTo(secret));
+                Assert.That(message.SubProperty.Secret.Value, Is.EqualTo(secret));
+            }
+        });
+    }
+
+    public class Context : ScenarioContext
+    {
+        public List<MessageWithSecretData> MessagesReceived { get; } = [];
+    }
+
+    public class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint() => EndpointSetup<DefaultServer>(config =>
+        {
+            var encryptionService = new AesEncryptionService("1st", new Dictionary<string, byte[]> { { "1st", "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"u8.ToArray() } });
+            config.EnableMessagePropertyEncryption(encryptionService, property => property.Name.StartsWith("Encrypted") || property.PropertyType == typeof(EncryptedString));
+        });
+
+        public class Handler(Context testContext) : IHandleMessages<MessageWithSecretData>
+        {
+            public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
+            {
+                testContext.MessagesReceived.Add(message);
+                testContext.MarkAsCompleted(testContext.MessagesReceived.Count == 2);
+
+                return Task.FromResult(0);
+            }
+        }
+    }
+
+    public class MessageWithSecretData : IMessage
+    {
+        public EncryptedString Secret { get; set; }
+        public MySecretSubProperty SubProperty { get; set; }
+        public string EncryptedString { get; set; }
+    }
+
+    public class MySecretSubProperty
+    {
+        public EncryptedString Secret { get; set; }
+    }
+}

--- a/src/AcceptanceTests/When_using_Aes_with_custom.cs
+++ b/src/AcceptanceTests/When_using_Aes_with_custom.cs
@@ -1,121 +1,105 @@
-﻿namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests
+﻿namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using NUnit.Framework;
+
+public class When_using_Aes_with_custom : NServiceBusAcceptanceTest
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-    using System.Threading.Tasks;
-    using AcceptanceTesting;
-    using NUnit.Framework;
-
-    public class When_using_Aes_with_custom : NServiceBusAcceptanceTest
+    [Test]
+    public async Task Should_receive_decrypted_message()
     {
-        [Test]
-        public async Task Should_receive_decrypted_message()
+        var messageToSend = new MessageWithSecretData
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.When(session => session.SendLocal(new MessageWithSecretData
+            Secret = "betcha can't guess my secret",
+            SubProperty = new MySecretSubProperty { Secret = "My sub secret" },
+            CreditCards =
+            [
+                new CreditCardDetails
                 {
-                    Secret = "betcha can't guess my secret",
-                    SubProperty = new MySecretSubProperty
-                    {
-                        Secret = "My sub secret"
-                    },
-                    CreditCards =
-                    [
-                        new CreditCardDetails
-                        {
-                            ValidTo = DateTime.UtcNow.AddYears(1),
-                            Number = "312312312312312"
-                        },
-                        new CreditCardDetails
-                        {
-                            ValidTo = DateTime.UtcNow.AddYears(2),
-                            Number = "543645546546456"
-                        }
-                    ]
-                })))
-                .Done(c => c.GetTheMessage)
-                .Run();
+                    ValidTo = DateTime.UtcNow.AddYears(1),
+                    Number = "312312312312312"
+                },
+                new CreditCardDetails
+                {
+                    ValidTo = DateTime.UtcNow.AddYears(2),
+                    Number = "543645546546456"
+                }
+            ]
+        };
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(context.Secret, Is.EqualTo("betcha can't guess my secret"));
-                Assert.That(context.SubPropertySecret, Is.EqualTo("My sub secret"));
-            });
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Endpoint>(b => b.When(session => session.SendLocal(messageToSend)))
+            .Run();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Secret, Is.EqualTo(messageToSend.Secret.Value));
+            Assert.That(context.SubPropertySecret, Is.EqualTo(messageToSend.SubProperty.Secret.Value));
             Assert.That(context.CreditCards, Is.EquivalentTo(
             [
                 "312312312312312",
                 "543645546546456"
             ]));
+        });
+    }
+
+    public class Context : ScenarioContext
+    {
+        public string Secret { get; set; }
+
+        public string SubPropertySecret { get; set; }
+
+        public List<string> CreditCards { get; set; }
+    }
+
+    public class Endpoint : EndpointConfigurationBuilder
+    {
+        public Endpoint()
+        {
+            var keys = new Dictionary<string, byte[]> { { "1st", "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"u8.ToArray() } };
+
+            EndpointSetup<DefaultServer>(builder => builder.EnableMessagePropertyEncryption(new AesEncryptionService("1st", keys)));
         }
 
-        public class Context : ScenarioContext
+        public class Handler(Context testContext) : IHandleMessages<MessageWithSecretData>
         {
-            public bool GetTheMessage { get; set; }
-
-            public string Secret { get; set; }
-
-            public string SubPropertySecret { get; set; }
-
-            public List<string> CreditCards { get; set; }
-        }
-
-        public class Endpoint : EndpointConfigurationBuilder
-        {
-            public Endpoint()
+            public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
             {
-                var keys = new Dictionary<string, byte[]>
-                {
-                    {"1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")}
-                };
+                testContext.Secret = message.Secret.Value;
 
-                EndpointSetup<DefaultServer>(builder => builder.EnableMessagePropertyEncryption(new AesEncryptionService("1st", keys)));
-            }
+                testContext.SubPropertySecret = message.SubProperty.Secret.Value;
 
-            public class Handler : IHandleMessages<MessageWithSecretData>
-            {
-                Context testContext;
+                testContext.CreditCards =
+                [
+                    message.CreditCards[0].Number.Value,
+                    message.CreditCards[1].Number.Value
+                ];
 
-                public Handler(Context testContext)
-                {
-                    this.testContext = testContext;
-                }
+                testContext.MarkAsCompleted();
 
-                public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
-                {
-                    testContext.Secret = message.Secret.Value;
-
-                    testContext.SubPropertySecret = message.SubProperty.Secret.Value;
-
-                    testContext.CreditCards =
-                    [
-                        message.CreditCards[0].Number.Value,
-                        message.CreditCards[1].Number.Value
-                    ];
-
-                    testContext.GetTheMessage = true;
-
-                    return Task.FromResult(0);
-                }
+                return Task.FromResult(0);
             }
         }
+    }
 
-        public class MessageWithSecretData : IMessage
-        {
-            public EncryptedString Secret { get; set; }
-            public MySecretSubProperty SubProperty { get; set; }
-            public List<CreditCardDetails> CreditCards { get; set; }
-        }
+    public class MessageWithSecretData : IMessage
+    {
+        public EncryptedString Secret { get; set; }
+        public MySecretSubProperty SubProperty { get; set; }
+        public List<CreditCardDetails> CreditCards { get; set; }
+    }
 
-        public class CreditCardDetails
-        {
-            public DateTime ValidTo { get; set; }
-            public EncryptedString Number { get; set; }
-        }
+    public class CreditCardDetails
+    {
+        public DateTime ValidTo { get; set; }
+        public EncryptedString Number { get; set; }
+    }
 
-        public class MySecretSubProperty
-        {
-            public EncryptedString Secret { get; set; }
-        }
+    public class MySecretSubProperty
+    {
+        public EncryptedString Secret { get; set; }
     }
 }

--- a/src/AcceptanceTests/When_using_Aes_with_unobtrusive_mode.cs
+++ b/src/AcceptanceTests/When_using_Aes_with_unobtrusive_mode.cs
@@ -1,133 +1,124 @@
-namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests
+namespace NServiceBus.Encryption.MessageProperty.AcceptanceTests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using NUnit.Framework;
+
+public class When_using_Aes_with_unobtrusive_mode : NServiceBusAcceptanceTest
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
-    using NUnit.Framework;
-
-    public class When_using_Aes_with_unobtrusive_mode : NServiceBusAcceptanceTest
+    [Test]
+    public async Task Should_receive_decrypted_message()
     {
-        [Test]
-        public async Task Should_receive_decrypted_message()
+        var messageToSend = new MessageWithSecretData
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MessageWithSecretData
+            EncryptedSecret = "betcha can't guess my secret",
+            SubProperty = new MySecretSubProperty { EncryptedSecret = "My sub secret" },
+            CreditCards =
+            [
+                new CreditCardDetails
                 {
-                    EncryptedSecret = "betcha can't guess my secret",
-                    SubProperty = new MySecretSubProperty
-                    {
-                        EncryptedSecret = "My sub secret"
-                    },
-                    CreditCards =
-                    [
-                        new CreditCardDetails
-                        {
-                            ValidTo = DateTime.UtcNow.AddYears(1),
-                            EncryptedNumber = "312312312312312"
-                        },
-                        new CreditCardDetails
-                        {
-                            ValidTo = DateTime.UtcNow.AddYears(2),
-                            EncryptedNumber = "543645546546456"
-                        }
-                    ]
-                })))
-                .WithEndpoint<Receiver>()
-                .Done(c => c.GetTheMessage || c.FailedMessages.Any())
-                .Run();
+                    ValidTo = DateTime.UtcNow.AddYears(1),
+                    EncryptedNumber = "312312312312312"
+                },
+                new CreditCardDetails
+                {
+                    ValidTo = DateTime.UtcNow.AddYears(2),
+                    EncryptedNumber = "543645546546456"
+                }
+            ]
+        };
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(context.Secret, Is.EqualTo("betcha can't guess my secret"));
-                Assert.That(context.SubPropertySecret, Is.EqualTo("My sub secret"));
-            });
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<Sender>(b => b.When(session => session.Send(messageToSend)))
+            .WithEndpoint<Receiver>()
+            .Run();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Secret, Is.EqualTo(messageToSend.EncryptedSecret));
+            Assert.That(context.SubPropertySecret, Is.EqualTo(messageToSend.SubProperty.EncryptedSecret));
             Assert.That(context.CreditCards, Is.EquivalentTo(
             [
                 "312312312312312",
                 "543645546546456"
             ]));
-        }
+        });
+    }
 
-        static readonly Dictionary<string, byte[]> Keys = new()
-        {
-            {"1st", "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"u8.ToArray()}
-        };
+    static readonly Dictionary<string, byte[]> Keys = new() { { "1st", "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"u8.ToArray() } };
 
-        public class Context : ScenarioContext
-        {
-            public bool GetTheMessage { get; set; }
+    public class Context : ScenarioContext
+    {
+        public string Secret { get; set; }
 
-            public string Secret { get; set; }
+        public string SubPropertySecret { get; set; }
 
-            public string SubPropertySecret { get; set; }
+        public List<string> CreditCards { get; set; }
+    }
 
-            public List<string> CreditCards { get; set; }
-        }
-
-        public class Sender : EndpointConfigurationBuilder
-        {
-            public Sender() =>
-                EndpointSetup<DefaultServer>(c =>
-                    {
-                        c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName);
-
-                        c.EnableMessagePropertyEncryption(new AesEncryptionService("1st", Keys), t => t.Name.StartsWith("Encrypted"));
-
-                        c.ConfigureRouting()
-                            .RouteToEndpoint(typeof(MessageWithSecretData), Conventions.EndpointNamingConvention(typeof(Receiver)));
-                    });
-        }
-
-        public class Receiver : EndpointConfigurationBuilder
-        {
-            public Receiver() =>
-                EndpointSetup<DefaultServer>(c =>
-                {
-                    c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName);
-
-                    c.EnableMessagePropertyEncryption(new AesEncryptionService("1st", Keys), t => t.Name.StartsWith("Encrypted"));
-                });
-
-            public class Handler(Context testContext) : IHandleMessages<MessageWithSecretData>
+    public class Sender : EndpointConfigurationBuilder
+    {
+        public Sender() =>
+            EndpointSetup<DefaultServer>(c =>
             {
-                public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
-                {
-                    testContext.Secret = message.EncryptedSecret;
+                c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName);
 
-                    testContext.SubPropertySecret = message.SubProperty.EncryptedSecret;
+                c.EnableMessagePropertyEncryption(new AesEncryptionService("1st", Keys), t => t.Name.StartsWith("Encrypted"));
 
-                    testContext.CreditCards =
-                    [
-                        message.CreditCards[0].EncryptedNumber,
-                        message.CreditCards[1].EncryptedNumber
-                    ];
+                c.ConfigureRouting()
+                    .RouteToEndpoint(typeof(MessageWithSecretData), Conventions.EndpointNamingConvention(typeof(Receiver)));
+            });
+    }
 
-                    testContext.GetTheMessage = true;
+    public class Receiver : EndpointConfigurationBuilder
+    {
+        public Receiver() =>
+            EndpointSetup<DefaultServer>(c =>
+            {
+                c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName);
 
-                    return Task.CompletedTask;
-                }
+                c.EnableMessagePropertyEncryption(new AesEncryptionService("1st", Keys), t => t.Name.StartsWith("Encrypted"));
+            });
+
+        public class Handler(Context testContext) : IHandleMessages<MessageWithSecretData>
+        {
+            public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
+            {
+                testContext.Secret = message.EncryptedSecret;
+
+                testContext.SubPropertySecret = message.SubProperty.EncryptedSecret;
+
+                testContext.CreditCards =
+                [
+                    message.CreditCards[0].EncryptedNumber,
+                    message.CreditCards[1].EncryptedNumber
+                ];
+
+                testContext.MarkAsCompleted();
+
+                return Task.CompletedTask;
             }
         }
+    }
 
-        public class MessageWithSecretData
-        {
-            public string EncryptedSecret { get; set; }
-            public MySecretSubProperty SubProperty { get; set; }
-            public List<CreditCardDetails> CreditCards { get; set; }
-        }
+    public class MessageWithSecretData
+    {
+        public string EncryptedSecret { get; set; }
+        public MySecretSubProperty SubProperty { get; set; }
+        public List<CreditCardDetails> CreditCards { get; set; }
+    }
 
-        public class CreditCardDetails
-        {
-            public DateTime ValidTo { get; set; }
-            public string EncryptedNumber { get; set; }
-        }
+    public class CreditCardDetails
+    {
+        public DateTime ValidTo { get; set; }
+        public string EncryptedNumber { get; set; }
+    }
 
-        public class MySecretSubProperty
-        {
-            public string EncryptedSecret { get; set; }
-        }
+    public class MySecretSubProperty
+    {
+        public string EncryptedSecret { get; set; }
     }
 }

--- a/src/MessageProperty/DecryptBehavior.cs
+++ b/src/MessageProperty/DecryptBehavior.cs
@@ -17,9 +17,9 @@ namespace NServiceBus.Encryption.MessageProperty
         {
             var current = context.Message.Instance;
 
-            foreach (var item in messageInspector.ScanObject(current))
+            foreach (var (target, member) in messageInspector.ScanObject(current))
             {
-                DecryptMember(item.Item1, item.Item2, context);
+                DecryptMember(target, member, context);
             }
 
             context.UpdateMessageInstance(current);

--- a/src/MessageProperty/EncryptBehavior.cs
+++ b/src/MessageProperty/EncryptBehavior.cs
@@ -1,63 +1,76 @@
 ﻿namespace NServiceBus.Encryption.MessageProperty
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
     using Pipeline;
 
-    class EncryptBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
+    class EncryptBehavior(EncryptionInspector messageInspector, IEncryptionService encryptionService) : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
     {
-        public EncryptBehavior(EncryptionInspector messageInspector, IEncryptionService encryptionService)
-        {
-            this.messageInspector = messageInspector;
-            this.encryptionService = encryptionService;
-        }
-
-        public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+        public async Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
             var currentMessageToSend = context.Message.Instance;
 
-            foreach (var item in messageInspector.ScanObject(currentMessageToSend))
+            var propertiesToRestore = new List<(object unencryptedValue, object target, MemberInfo member)>();
+            var propertiesToEncrypt = messageInspector.ScanObject(currentMessageToSend);
+
+            try
             {
-                EncryptMember(item.Item1, item.Item2, context);
+                foreach (var (target, member) in propertiesToEncrypt)
+                {
+                    var oldValue = EncryptMember(target, member, context);
+
+                    propertiesToRestore.Add((oldValue, target, member));
+                }
+
+                context.UpdateMessage(currentMessageToSend);
+
+                await next(context).ConfigureAwait(false);
             }
+            finally
+            {
+                if (propertiesToEncrypt.Any())
+                {
+                    foreach (var propertyToRestore in propertiesToRestore)
+                    {
+                        propertyToRestore.member.SetValue(propertyToRestore.target, propertyToRestore.unencryptedValue);
+                    }
 
-            context.UpdateMessage(currentMessageToSend);
-
-            return next(context);
+                    context.UpdateMessage(currentMessageToSend);
+                }
+            }
         }
 
-        void EncryptMember(object message, MemberInfo member, IOutgoingLogicalMessageContext context)
+        object EncryptMember(object message, MemberInfo member, IOutgoingLogicalMessageContext context)
         {
             var valueToEncrypt = member.GetValue(message);
 
             if (valueToEncrypt is EncryptedString wireEncryptedString)
             {
+                var unencryptedValue = new EncryptedString { Value = wireEncryptedString.Value };
                 encryptionService.EncryptValue(wireEncryptedString, context);
-                return;
+                return unencryptedValue;
             }
 
             if (valueToEncrypt is string stringToEncrypt)
             {
+                var unencryptedValue = stringToEncrypt;
                 encryptionService.EncryptValue(ref stringToEncrypt, context);
 
                 member.SetValue(message, stringToEncrypt);
-                return;
+                return unencryptedValue;
             }
 
             throw new Exception("Only string properties are supported for convention based encryption. Check the configured conventions.");
         }
 
-        IEncryptionService encryptionService;
-        EncryptionInspector messageInspector;
-
         public class EncryptRegistration : RegisterStep
         {
             public EncryptRegistration(EncryptionInspector inspector, IEncryptionService encryptionService)
-                : base("MessagePropertyEncryption", typeof(EncryptBehavior), "Invokes the encryption logic", b => new EncryptBehavior(inspector, encryptionService))
-            {
+                : base("MessagePropertyEncryption", typeof(EncryptBehavior), "Invokes the encryption logic", b => new EncryptBehavior(inspector, encryptionService)) =>
                 InsertAfter("MutateOutgoingMessages");
-            }
         }
     }
 }

--- a/src/MessageProperty/EncryptionInspector.cs
+++ b/src/MessageProperty/EncryptionInspector.cs
@@ -47,7 +47,7 @@ namespace NServiceBus.Encryption.MessageProperty
             return false;
         }
 
-        public List<Tuple<object, MemberInfo>> ScanObject(object root)
+        public List<(object target, MemberInfo member)> ScanObject(object root)
         {
 #pragma warning disable PS0025 // Dictionary keys should implement IEquatable<T> - Valid use for object counting
             var visitedMembers = new HashSet<object>();
@@ -56,7 +56,7 @@ namespace NServiceBus.Encryption.MessageProperty
         }
 
 #pragma warning disable PS0025 // Dictionary keys should implement IEquatable<T> - Valid use for object counting
-        List<Tuple<object, MemberInfo>> ScanObject(object root, HashSet<object> visitedMembers)
+        List<(object target, MemberInfo member)> ScanObject(object root, HashSet<object> visitedMembers)
 #pragma warning restore PS0025 // Dictionary keys should implement IEquatable<T>
         {
             if (root == null || visitedMembers.Contains(root))
@@ -68,7 +68,7 @@ namespace NServiceBus.Encryption.MessageProperty
 
             var members = GetFieldsAndProperties(root);
 
-            var properties = new List<Tuple<object, MemberInfo>>();
+            var properties = new List<(object target, MemberInfo member)>();
 
             foreach (var member in members)
             {
@@ -77,7 +77,7 @@ namespace NServiceBus.Encryption.MessageProperty
                     var value = member.GetValue(root);
                     if (value is string or EncryptedString)
                     {
-                        properties.Add(Tuple.Create(root, member));
+                        properties.Add((root, member));
                         continue;
                     }
                     throw new Exception("Only string properties are supported for convention based encryption. Check the configured conventions.");
@@ -161,7 +161,7 @@ namespace NServiceBus.Encryption.MessageProperty
 
         static List<MemberInfo> NoMembers = [];
 
-        static List<Tuple<object, MemberInfo>> AlreadyVisited = [];
+        static List<(object target, MemberInfo member)> AlreadyVisited = [];
 
         static ConcurrentDictionary<RuntimeTypeHandle, List<MemberInfo>> cache = new ConcurrentDictionary<RuntimeTypeHandle, List<MemberInfo>>();
     }

--- a/src/Tests/ConventionBasedEncryptedStringSpecs.cs
+++ b/src/Tests/ConventionBasedEncryptedStringSpecs.cs
@@ -19,7 +19,7 @@
             var result = inspector.ScanObject(message).ToList();
 
             Assert.That(result, Has.Count.EqualTo(1));
-            Assert.That(result[0].Item2.Name, Is.EqualTo("EncryptedSecret"));
+            Assert.That(result[0].member.Name, Is.EqualTo("EncryptedSecret"));
         }
     }
 

--- a/src/Tests/WireEncryptedStringSpecs.cs
+++ b/src/Tests/WireEncryptedStringSpecs.cs
@@ -27,7 +27,7 @@
             message.ListOfSecrets = [.. message.ListOfCreditCards];
 
             var result = inspector.ScanObject(message).ToList();
-            result.ForEach(x => x.Item2.SetValue(x.Item1, Create()));
+            result.ForEach(x => x.member.SetValue(x.target, Create()));
 
             Assert.Multiple(() =>
             {
@@ -62,7 +62,7 @@
             var result = inspector.ScanObject(message).ToList();
 
             Assert.That(result, Has.Count.EqualTo(1));
-            Assert.That(result[0].Item2.GetValue(result[0].Item1), Is.SameAs(message.Secret));
+            Assert.That(result[0].member.GetValue(result[0].target), Is.SameAs(message.Secret));
         }
 
         public class MessageWithIndexedProperties : IMessage
@@ -124,7 +124,7 @@
             var result = inspector.ScanObject(message).ToList();
 
             Assert.That(result, Has.Count.EqualTo(1));
-            Assert.That(result[0].Item2.Name, Is.EqualTo("Secret"));
+            Assert.That(result[0].member.Name, Is.EqualTo("Secret"));
         }
     }
 
@@ -143,7 +143,7 @@
             inspector
                 .ScanObject(message)
                 .ToList()
-                .ForEach(x => x.Item2.SetValue(x.Item1, (EncryptedString)MySecretMessage));
+                .ForEach(x => x.member.SetValue(x.target, (EncryptedString)MySecretMessage));
 
             Assert.That(message.MySecret.Value, Is.EqualTo(MySecretMessage));
         }
@@ -172,7 +172,7 @@
             inspector
                 .ScanObject(message)
                 .ToList()
-                .ForEach(x => x.Item2.SetValue(x.Item1, Create()));
+                .ForEach(x => x.member.SetValue(x.target, Create()));
 
             Assert.That(MySecretMessage, Is.EqualTo(message.Secret.Value));
         }
@@ -195,7 +195,7 @@
             inspector
                 .ScanObject(message)
                 .ToList()
-                .ForEach(x => x.Item2.SetValue(x.Item1, Create()));
+                .ForEach(x => x.member.SetValue(x.target, Create()));
 
             Assert.Multiple(() =>
             {


### PR DESCRIPTION
Backport of:
-  #713 

Which fixes for the `release-6.0` branch:
- #711 